### PR TITLE
CP-382 : Avoid the creation of the payment line

### DIFF
--- a/compassion_nordic_accounting/__manifest__.py
+++ b/compassion_nordic_accounting/__manifest__.py
@@ -39,6 +39,7 @@
         # OCA/bank-payment
         "account_banking_pain_base",
         "account_banking_mandate",
+        "account_payment_order",
         # OCA/partner-contact
         "partner_contact_birthdate",
         # OCA/account-invoicing
@@ -52,6 +53,7 @@
     ],
     "data": [
         "views/account_move_view.xml",
+        "views/account_payment_order.xml",
         "views/load_mandate_wizard_view.xml",
         "views/partner_tax_file_res.xml",
         "views/menu_finance_receivables.xml",

--- a/compassion_nordic_accounting/models/__init__.py
+++ b/compassion_nordic_accounting/models/__init__.py
@@ -9,6 +9,8 @@
 ##############################################################################
 from . import account_banking_mandate_compassion
 from . import account_move
+from . import account_payment
+from . import account_payment_order
 from . import bank_statement
 from . import mandate_staff_notif_settings
 from . import partner_tax_file_res

--- a/compassion_nordic_accounting/models/account_payment.py
+++ b/compassion_nordic_accounting/models/account_payment.py
@@ -1,0 +1,13 @@
+from odoo import models, api
+
+
+class AccountPayment(models.Model):
+    _name = 'account.payment'
+    _inherit = 'account.payment'
+
+    @api.model
+    def create(self, vals_list):
+        if self.env.context.get('skip_payment_line', False):
+            return self
+        else:
+            return super().create(vals_list)

--- a/compassion_nordic_accounting/models/account_payment_order.py
+++ b/compassion_nordic_accounting/models/account_payment_order.py
@@ -1,0 +1,14 @@
+from odoo import models, fields
+
+
+class AccountPaymentOrder(models.Model):
+    _inherit = 'account.payment.order'
+
+    skip_payment_line = fields.Boolean(string="Skip payment lines",
+                                       help="Should the payment lines be generated ?",
+                                       default=True)
+
+    def draft2open(self):
+        ctx = self.env.context.copy()
+        ctx.update({"skip_payment_line": self.skip_payment_line})
+        return super(AccountPaymentOrder, self.with_context(ctx)).draft2open()

--- a/compassion_nordic_accounting/models/account_payment_order.py
+++ b/compassion_nordic_accounting/models/account_payment_order.py
@@ -5,7 +5,6 @@ class AccountPaymentOrder(models.Model):
     _inherit = 'account.payment.order'
 
     skip_payment_line = fields.Boolean(string="Skip payment lines",
-                                       help="Should the payment lines be generated ?",
                                        default=True)
 
     def draft2open(self):

--- a/compassion_nordic_accounting/models/account_payment_order.py
+++ b/compassion_nordic_accounting/models/account_payment_order.py
@@ -8,6 +8,4 @@ class AccountPaymentOrder(models.Model):
                                        default=True)
 
     def draft2open(self):
-        ctx = self.env.context.copy()
-        ctx.update({"skip_payment_line": self.skip_payment_line})
-        return super(AccountPaymentOrder, self.with_context(ctx)).draft2open()
+        return super(AccountPaymentOrder, self.with_context(skip_payment_line=self.skip_payment_line)).draft2open()

--- a/compassion_nordic_accounting/views/account_payment_order.xml
+++ b/compassion_nordic_accounting/views/account_payment_order.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="account_payment_order_nordic" model="ir.ui.view">
+        <field name="name">account.payment.order.nordic.id</field>
+        <field name="model">account.payment.order</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_order_form"/>
+        <field name="arch" type="xml">
+            <field name="description" position="before">
+                <field name="skip_payment_line" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
we don't use it in compassion processes.
That can be managed by an option on the debit order to generate or not the payment line. Avoiding the generation of the payment lines should optimise the process time.