### PR TITLE
[ADD] Cron for Nordic rate change process

### DIFF
--- a/compassion_nordic_accounting/__manifest__.py
+++ b/compassion_nordic_accounting/__manifest__.py
@@ -52,6 +52,7 @@
         "web_notify"
     ],
     "data": [
+        "data/ir_cron.xml",
         "views/account_move_view.xml",
         "views/account_payment_order.xml",
         "views/load_mandate_wizard_view.xml",

--- a/compassion_nordic_accounting/data/ir_cron.xml
+++ b/compassion_nordic_accounting/data/ir_cron.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record forcecreate="True" id="rate_change_fix_next_invoices" model="ir.cron">
+            <field name="name">Rate change: remove balance for future invoices.</field>
+            <field name="model_id" ref="model_account_move"/>
+            <field name="state">code</field>
+            <field name="code">model._prepare_rate_change(rate_change_date='2023-05-01')</field>
+            <field eval="True" name="active" />
+            <field name="user_id" ref="base.user_root" />
+            <field name="interval_number" eval="False"/>
+            <field name="interval_type" eval="False"/>
+            <field name="nextcall">2023-04-01 05:00:00</field>
+            <field name="numbercall">1</field>
+        </record>
+        <record forcecreate="True" id="rate_change_fix_contracts" model="ir.cron">
+            <field name="name">Rate change: remove balance in contracts.</field>
+            <field name="model_id" ref="model_recurring_contract_line"/>
+            <field name="state">code</field>
+            <field name="code">model._remove_balance()</field>
+            <field eval="True" name="active" />
+            <field name="user_id" ref="base.user_root" />
+            <field name="interval_number" eval="False"/>
+            <field name="interval_type" eval="False"/>
+            <field name="nextcall">2023-05-01 05:00:00</field>
+            <field name="numbercall">1</field>
+        </record>
+    </data>
+</odoo>

--- a/compassion_nordic_accounting/models/recurring_contract.py
+++ b/compassion_nordic_accounting/models/recurring_contract.py
@@ -8,7 +8,8 @@
 #
 ##############################################################################
 
-from odoo import api, fields, models, _
+from odoo import fields, models, _
+
 
 class RecurringContract(models.Model):
     _inherit = "recurring.contract"
@@ -17,12 +18,6 @@ class RecurringContract(models.Model):
         # Show selection of all companies except Norden (id = 1)
         domain="[('id', '!=', 1)]",
     )
-
-    @api.onchange('partner_id')
-    def change_price(self):
-        if self.partner_id.property_product_pricelist.exists():
-            for f in self.contract_line_ids:
-                f.recompute_price(self.partner_id.property_product_pricelist)
 
     def _filter_open_invoices_to_cancel(self):
         """

--- a/compassion_nordic_accounting/models/recurring_contract_line.py
+++ b/compassion_nordic_accounting/models/recurring_contract_line.py
@@ -1,16 +1,6 @@
-##############################################################################
-#
-#    Copyright (C) 2022 Compassion CH (http://www.compassion.ch)
-#    Releasing children from poverty
-#    @author: Robin Berguerand (robin.berguerand@gmail.com)
-#
-#    The licence is in the file __manifest__.py
-#
-##############################################################################
-
 import logging
 
-from odoo import api, fields, models
+from odoo import models
 
 _logger = logging.getLogger(__name__)
 
@@ -18,6 +8,8 @@ _logger = logging.getLogger(__name__)
 class ContractLine(models.Model):
     _inherit = "recurring.contract.line"
 
-    def recompute_price(self, pricelist_id):
-        data = pricelist_id.price_get(self.product_id.id, 1)
-        self.amount = data[pricelist_id.id]
+    def _remove_balance(self):
+        balance_product = self.env.ref("recurring_contract.product_balance_migr")
+        lines = self.search([("product_id", "=", balance_product.id)])
+        _logger.info("Removed %s balance lines", str(len(lines)))
+        return lines.unlink()


### PR DESCRIPTION
- One cron will remove the balance product from open invoices that will be generated before the rate change happens.
- The second cron will remove the balance product from all sponsorships.
- Those cron will be executed only once, but contain the logic for the transition to be smooth and correct.
- TODO the correct dates should be entered in the database, one month before the rate change, when invoices are generated and then just after the rate change for the second CRON.
- Remove also useless onchange method.