### PR TITLE
T0368 Disable asynchronous sponsorship validation

### DIFF
--- a/partner_communication_nordic/models/contracts.py
+++ b/partner_communication_nordic/models/contracts.py
@@ -30,6 +30,7 @@ class RecurringContract(models.Model):
     )
 
     def contract_waiting(self):
+        self = self.with_context(async_mode=False) # Disable asynchronous to prevent serialization errors
         res = super().contract_waiting()
         self.filtered(lambda c: "S" in c.type and not c.is_active).with_context({})._new_dossier()
         return res


### PR DESCRIPTION
Concerned ticket: T0368

When validating a sponsorship, there is a serialization failure preventing the related processes to work correctly (communication/invoices generations for the new sponsorship)

Testing the issue in a local environment, the issue is none existent,
it's something more related to the environment than to the code,

A way to resolve it is to make all related processes synchronously by setting the context with async_mode to False

