### PR TITLE
T0597 BUG: Correct a bug on the import of mandate for  wrong partner id

### DIFF
--- a/compassion_denmark_payment/wizards/load_mandate_wizard.py
+++ b/compassion_denmark_payment/wizards/load_mandate_wizard.py
@@ -45,69 +45,75 @@ class LoadMandateWizard(models.Model):
                     for info in sections.information_list:
                         # Variables for the logging of what the process do
                         mandate_id = None
+                        kid = ""
                         old_state = "Active"
                         is_cancelled = False
                         # Actual behaviour
                         partner = self.env['res.partner'].search([('ref', '=', int(info.customer_number))])
-                        if info.transaction_code in [beservice.TransactionCode.MANDATE_CANCELLED_BY_BANK,
-                                                     beservice.TransactionCode.MANDATE_CANCELLED_BY_BETALINGSSERVICE,
-                                                     beservice.TransactionCode.MANDATE_CANCELLED_BY_CREDITOR]:
-                            is_cancelled = True
-                            res = self.env['recurring.contract.group'].search([('ref', '=', info.mandate_number)])
-                            if not res:
-                                raise ValidationError(
-                                    _(
-                                        "Contract Group '%s' does not exists"
-                                    )
-                                    % info.mandate_number)
-                            mandate = partner.valid_mandate_id
-                            mandate.cancel()
-                            mandate_id = mandate.id
-                            # We have to set the payment mode to bank transfer again
-                            active_dd_contract = partner.sponsorship_ids.filtered(
-                                lambda a: a.state not in ('terminated', 'cancelled')
-                                          and a.group_id.ref == info.mandate_number)
-                            payment_mode_id = self.env['account.payment.mode'].search([
-                                ('payment_method_id.code', '=', 'manual'),
-                                ('company_id', '=', self.env.company.id)], limit=1).id
-                            active_dd_contract.group_id.update({'payment_mode_id': payment_mode_id})
-                        elif info.transaction_code == beservice.TransactionCode.MANDATE_REGISTERED:
-                            old_state = "None"
-                            # we need to update all contract that the sponsor pays with the new mandate number received.
-                            active_dd_contract = partner.sponsorship_ids.filtered(lambda a: a.state not in ('terminated', 'cancelled'))
-                            payment_mode_id = self.env['account.payment.mode'].search([
-                                ('payment_method_id.code', '=', 'denmark_direct_debit')], limit=1).id
-                            active_dd_contract.group_id.update({'ref': info.mandate_number,
-                                                                'payment_mode_id': payment_mode_id})
-                            company_id = self.env.company.id
-                            bank_account = partner.bank_ids.filtered(lambda b: b.acc_number == info.customer_number)
-                            if not bank_account:
-                                bank_account = self.env["res.partner.bank"].create(
-                                    {
-                                        "acc_number": info.customer_number,
-                                        "partner_id": partner.id,
-                                        "company_id": company_id
-                                    }
-                                )
-                            valid = bank_account.mandate_ids.filtered(lambda m: m.state == "valid")
-
-                            if not valid:
-                                mandate = self.env["account.banking.mandate"].create(
-                                    {
-                                        "type": "generic",
-                                        "format": "basic",
-                                        "partner_bank_id": bank_account.id,
-                                        "signature_date": date.today(),
-                                        "company_id": company_id,
-                                    }
-                                )
-                                mandate.validate()
+                        if partner:
+                            if info.transaction_code in [beservice.TransactionCode.MANDATE_CANCELLED_BY_BANK,
+                                                         beservice.TransactionCode.MANDATE_CANCELLED_BY_BETALINGSSERVICE,
+                                                         beservice.TransactionCode.MANDATE_CANCELLED_BY_CREDITOR]:
+                                is_cancelled = True
+                                res = self.env['recurring.contract.group'].search([('ref', '=', info.mandate_number)])
+                                if not res:
+                                    raise ValidationError(
+                                        _(
+                                            "Contract Group '%s' does not exists"
+                                        )
+                                        % info.mandate_number)
+                                mandate = partner.valid_mandate_id
+                                mandate.cancel()
                                 mandate_id = mandate.id
-                            else:
-                                mandate_id = valid.id
+                                # We have to set the payment mode to bank transfer again
+                                active_dd_contract = partner.sponsorship_ids.filtered(
+                                    lambda a: a.state not in ('terminated', 'cancelled')
+                                              and a.group_id.ref == info.mandate_number)
+                                payment_mode_id = self.env['account.payment.mode'].search([
+                                    ('payment_method_id.code', '=', 'manual'),
+                                    ('company_id', '=', self.env.company.id)], limit=1).id
+                                active_dd_contract.group_id.update({'payment_mode_id': payment_mode_id})
+                            elif info.transaction_code == beservice.TransactionCode.MANDATE_REGISTERED:
+                                old_state = "None"
+                                # we need to update all contract that the sponsor pays with the new mandate number received.
+                                active_dd_contract = partner.sponsorship_ids.filtered(lambda a: a.state not in ('terminated', 'cancelled'))
+                                payment_mode_id = self.env['account.payment.mode'].search([
+                                    ('payment_method_id.code', '=', 'denmark_direct_debit')], limit=1).id
+                                active_dd_contract.group_id.update({'ref': info.mandate_number,
+                                                                    'payment_mode_id': payment_mode_id})
+                                company_id = self.env.company.id
+                                bank_account = partner.bank_ids.filtered(lambda b: b.acc_number == info.customer_number)
+                                if not bank_account:
+                                    bank_account = self.env["res.partner.bank"].create(
+                                        {
+                                            "acc_number": info.customer_number,
+                                            "partner_id": partner.id,
+                                            "company_id": company_id
+                                        }
+                                    )
+                                valid = bank_account.mandate_ids.filtered(lambda m: m.state == "valid")
+
+                                if not valid:
+                                    mandate = self.env["account.banking.mandate"].create(
+                                        {
+                                            "type": "generic",
+                                            "format": "basic",
+                                            "partner_bank_id": bank_account.id,
+                                            "signature_date": date.today(),
+                                            "company_id": company_id,
+                                        }
+                                    )
+                                    mandate.validate()
+                                    mandate_id = mandate.id
+                                else:
+                                    mandate_id = valid.id
+                        else:
+                            old_state = "error"
+                            kid = info.customer_number
+
                         data_dict = {"name_file": wizard.name_file, 'mandate_id': mandate_id,
                                      'old_mandate_state': old_state, 'is_cancelled': is_cancelled,
-                                     'partner_id': partner.id}
+                                     'partner_id': partner.id, 'kid': kid}
                         if data_dict['mandate_id'] not in data:
                             data.append(data_dict)
             self._log_results(data)

--- a/compassion_nordic_accounting/views/load_mandate_wizard_view.xml
+++ b/compassion_nordic_accounting/views/load_mandate_wizard_view.xml
@@ -29,6 +29,7 @@
         <field name="arch" type="xml">
             <tree decoration-danger="current_mandate_state == 'cancel'"
                   decoration-success="current_mandate_state == 'valid'"
+                  decoration-warning="current_mandate_state == 'error'"
                   create="false"
                   edit="false"
                   delete="true"

--- a/compassion_nordic_accounting/wizards/load_mandate_wizard.py
+++ b/compassion_nordic_accounting/wizards/load_mandate_wizard.py
@@ -49,7 +49,7 @@ class LoadMandateWizard(models.Model):
     def _compute_all(self):
         for rec in self:
             rec.partner_id = rec.mandate_id.partner_id if rec.mandate_id else rec.partner_id
-            rec.company_id = rec.mandate_id.company_id
+            rec.company_id = rec.mandate_id.company_id if rec.mandate_id else rec.company_id
             if rec.mandate_id:
                 current_state = rec.mandate_id.state
             elif rec.is_cancelled:


### PR DESCRIPTION
Sometime mandate come with a wrong partner id. In this case  the wizard failed and import nothing.

This commit add a workaround. all the right mandate are imported, the other are add as error line in the loaded mandate page.