### PR TITLE
[T3196] FIX : fix direct debit invoice generation

### DIFF
--- a/compassion_denmark_payment/models/account_payment_order.py
+++ b/compassion_denmark_payment/models/account_payment_order.py
@@ -37,42 +37,55 @@ class AccountPaymentOrder(models.Model):
             debtor_group_number=1,
         )
 
+        # Here I probably need to create a single data_delivery.sections[0].add_payment instead of one in every loop
+        # so that I can merge the different products under a single bill
+        # Just have to check if it doesn't break other behavior, also could be good to know why this behavior changed
+
+        grouped_payments = {}
+
         for pymt_trx in self.payment_ids:
+            group_key = pymt_trx.payment_line_ids[0].move_line_id.move_id.line_ids.mapped("contract_id").group_id
+            if group_key not in grouped_payments:
+                grouped_payments[group_key] = []
+            grouped_payments[group_key].append(pymt_trx)
+
+        for contract_group in grouped_payments:
             text_lines = []
-            for line in pymt_trx.payment_line_ids:
-                for invoice_line in line.move_line_id.move_id.invoice_line_ids:
-                    child = invoice_line.contract_id.child_id
-                    str_child = ""
-                    product_name = invoice_line.product_id.with_context(
-                        lang=invoice_line.partner_id.lang
-                    ).name
-                    if child:
-                        # Build a string that looks like (BF Maria-Louisa)
-                        str_child = (
-                            f"({child.field_office_id.country_id.code + ' ' or None}"
-                            f"{child.preferred_name or None})"
+            for pymt_trx in grouped_payments[contract_group]:
+                for line in pymt_trx.payment_line_ids:
+                    for invoice_line in line.move_line_id.move_id.invoice_line_ids:
+                        child = invoice_line.contract_id.child_id
+                        str_child = ""
+                        product_name = invoice_line.product_id.with_context(
+                            lang=invoice_line.partner_id.lang
+                        ).name
+                        if child:
+                            # Build a string that looks like (BF Maria-Louisa)
+                            str_child = (
+                                f"({child.field_office_id.country_id.code + ' ' or None}"
+                                f"{child.preferred_name or None})"
+                            )
+                        text_lines.append(
+                            (
+                                invoice_line.product_id.id,
+                                f"{int(invoice_line.credit)} {product_name} " + str_child,
+                            )
                         )
-                    text_lines.append(
-                        (
-                            invoice_line.product_id.id,
-                            f"{int(invoice_line.credit)} {product_name} " + str_child,
-                        )
-                    )
             text_lines.sort(key=lambda a: a[0])
 
+            contract = grouped_payments[contract_group][0]
+
             data_delivery.sections[0].add_payment(
-                customer_number=f"{pymt_trx.partner_id.ref:15}",
-                mandate_number=pymt_trx.payment_line_ids[0]
-                .move_line_id.move_id.line_ids.mapped("contract_id")
-                .group_id.ref,
+                customer_number=f"{contract.partner_id.ref:15}",
+                mandate_number=contract_group.ref,
                 reference=(
-                    pymt_trx.payment_line_ids[0].date.strftime("%b").capitalize()
+                    contract.payment_line_ids[0].date.strftime("%b").capitalize()
                     + " "
-                    + pymt_trx.payment_line_ids[0].payment_type.capitalize()
+                    + contract.payment_line_ids[0].payment_type.capitalize()
                 )[:20],
-                amount=pymt_trx.amount,
+                amount= sum(pymt_trx.amount for pymt_trx in grouped_payments[contract_group]),
                 sign_code=beservice.SignCode.COLLECTION,
-                payment_date=pymt_trx.payment_line_ids[0].date,
+                payment_date=contract.payment_line_ids[0].date,
                 text_lines=text_lines,
             )
         return data_delivery.to_ocr().encode("iso-8859-1"), f"{self.name}.txt"

--- a/compassion_denmark_payment/models/account_payment_order.py
+++ b/compassion_denmark_payment/models/account_payment_order.py
@@ -43,7 +43,11 @@ class AccountPaymentOrder(models.Model):
         for pymt_trx in self.payment_ids:
             if not pymt_trx.payment_line_ids:
                 continue
-            group_key = pymt_trx.payment_line_ids[0].move_line_id.move_id.line_ids.mapped("contract_id").group_id[:1]
+            group_key = (
+                pymt_trx.payment_line_ids[0]
+                .move_line_id.move_id.line_ids.mapped("contract_id")
+                .group_id[:1]
+            )
             if group_key not in grouped_payment_transactions:
                 grouped_payment_transactions[group_key] = []
             grouped_payment_transactions[group_key].append(pymt_trx)
@@ -67,7 +71,8 @@ class AccountPaymentOrder(models.Model):
                         text_lines.append(
                             (
                                 invoice_line.product_id.id,
-                                f"{int(invoice_line.credit)} {product_name} " + str_child,
+                                f"{int(invoice_line.credit)} {product_name} "
+                                + str_child,
                             )
                         )
             text_lines.sort(key=lambda a: a[0])
@@ -82,7 +87,7 @@ class AccountPaymentOrder(models.Model):
                     + " "
                     + contract_group.payment_mode_id.payment_type.capitalize()
                 )[:20],
-                amount= sum(pymt_trx.amount for pymt_trx in transactions),
+                amount=sum(pymt_trx.amount for pymt_trx in transactions),
                 sign_code=beservice.SignCode.COLLECTION,
                 payment_date=payment_date,
                 text_lines=text_lines,

--- a/compassion_denmark_payment/models/account_payment_order.py
+++ b/compassion_denmark_payment/models/account_payment_order.py
@@ -69,19 +69,19 @@ class AccountPaymentOrder(models.Model):
                         )
             text_lines.sort(key=lambda a: a[0])
 
-            contract = transactions[0]
+            payment_date = transactions[0].payment_line_ids[0].date
 
             data_delivery.sections[0].add_payment(
-                customer_number=f"{contract.partner_id.ref:15}",
+                customer_number=f"{contract_group.partner_id.ref:15}",
                 mandate_number=contract_group.ref,
                 reference=(
-                    contract.payment_line_ids[0].date.strftime("%b").capitalize()
+                    payment_date.strftime("%b").capitalize()
                     + " "
-                    + contract.payment_line_ids[0].payment_type.capitalize()
+                    + contract_group.payment_mode_id.payment_type.capitalize()
                 )[:20],
                 amount= sum(pymt_trx.amount for pymt_trx in transactions),
                 sign_code=beservice.SignCode.COLLECTION,
-                payment_date=contract.payment_line_ids[0].date,
+                payment_date=payment_date,
                 text_lines=text_lines,
             )
         return data_delivery.to_ocr().encode("iso-8859-1"), f"{self.name}.txt"

--- a/compassion_denmark_payment/models/account_payment_order.py
+++ b/compassion_denmark_payment/models/account_payment_order.py
@@ -67,7 +67,10 @@ class AccountPaymentOrder(models.Model):
                             country_code = child.field_office_id.country_id.code
                             pref_name = child.preferred_name
                             if country_code or pref_name:
-                                str_child = f"({country_code + ' ' if country_code else ''}{pref_name or ''})"
+                                str_child = (
+                                    f"({country_code + ' ' if country_code else ''}"
+                                    f"{pref_name or ''})"
+                                )
                         text_lines.append(
                             (
                                 invoice_line.product_id.id,

--- a/compassion_denmark_payment/models/account_payment_order.py
+++ b/compassion_denmark_payment/models/account_payment_order.py
@@ -37,17 +37,17 @@ class AccountPaymentOrder(models.Model):
             debtor_group_number=1,
         )
 
-        grouped_payments = {}
+        grouped_payment_transactions = {}
 
         for pymt_trx in self.payment_ids:
             group_key = pymt_trx.payment_line_ids[0].move_line_id.move_id.line_ids.mapped("contract_id").group_id
-            if group_key not in grouped_payments:
-                grouped_payments[group_key] = []
-            grouped_payments[group_key].append(pymt_trx)
+            if group_key not in grouped_payment_transactions:
+                grouped_payment_transactions[group_key] = []
+            grouped_payment_transactions[group_key].append(pymt_trx)
 
-        for contract_group in grouped_payments:
+        for contract_group, transactions in grouped_payment_transactions.items():
             text_lines = []
-            for pymt_trx in grouped_payments[contract_group]:
+            for pymt_trx in transactions:
                 for line in pymt_trx.payment_line_ids:
                     for invoice_line in line.move_line_id.move_id.invoice_line_ids:
                         child = invoice_line.contract_id.child_id
@@ -69,7 +69,7 @@ class AccountPaymentOrder(models.Model):
                         )
             text_lines.sort(key=lambda a: a[0])
 
-            contract = grouped_payments[contract_group][0]
+            contract = transactions[0]
 
             data_delivery.sections[0].add_payment(
                 customer_number=f"{contract.partner_id.ref:15}",
@@ -79,7 +79,7 @@ class AccountPaymentOrder(models.Model):
                     + " "
                     + contract.payment_line_ids[0].payment_type.capitalize()
                 )[:20],
-                amount= sum(pymt_trx.amount for pymt_trx in grouped_payments[contract_group]),
+                amount= sum(pymt_trx.amount for pymt_trx in transactions),
                 sign_code=beservice.SignCode.COLLECTION,
                 payment_date=contract.payment_line_ids[0].date,
                 text_lines=text_lines,

--- a/compassion_denmark_payment/models/account_payment_order.py
+++ b/compassion_denmark_payment/models/account_payment_order.py
@@ -40,7 +40,9 @@ class AccountPaymentOrder(models.Model):
         grouped_payment_transactions = {}
 
         for pymt_trx in self.payment_ids:
-            group_key = pymt_trx.payment_line_ids[0].move_line_id.move_id.line_ids.mapped("contract_id").group_id
+            if not pymt_trx.payment_line_ids:
+                continue
+            group_key = pymt_trx.payment_line_ids[0].move_line_id.move_id.line_ids.mapped("contract_id").group_id[:1]
             if group_key not in grouped_payment_transactions:
                 grouped_payment_transactions[group_key] = []
             grouped_payment_transactions[group_key].append(pymt_trx)
@@ -57,10 +59,10 @@ class AccountPaymentOrder(models.Model):
                         ).name
                         if child:
                             # Build a string that looks like (BF Maria-Louisa)
-                            str_child = (
-                                f"({child.field_office_id.country_id.code + ' ' or None}"
-                                f"{child.preferred_name or None})"
-                            )
+                            country_code = child.field_office_id.country_id.code
+                            pref_name = child.preferred_name
+                            if country_code or pref_name:
+                                str_child = f"({country_code + ' ' if country_code else ''}{pref_name or ''})"
                         text_lines.append(
                             (
                                 invoice_line.product_id.id,

--- a/compassion_denmark_payment/models/account_payment_order.py
+++ b/compassion_denmark_payment/models/account_payment_order.py
@@ -37,10 +37,6 @@ class AccountPaymentOrder(models.Model):
             debtor_group_number=1,
         )
 
-        # Here I probably need to create a single data_delivery.sections[0].add_payment instead of one in every loop
-        # so that I can merge the different products under a single bill
-        # Just have to check if it doesn't break other behavior, also could be good to know why this behavior changed
-
         grouped_payments = {}
 
         for pymt_trx in self.payment_ids:

--- a/compassion_denmark_payment/models/account_payment_order.py
+++ b/compassion_denmark_payment/models/account_payment_order.py
@@ -39,6 +39,7 @@ class AccountPaymentOrder(models.Model):
 
         grouped_payment_transactions = {}
 
+        # Group payments under the same contract group
         for pymt_trx in self.payment_ids:
             if not pymt_trx.payment_line_ids:
                 continue


### PR DESCRIPTION
The goal is to fix the debit order file generation for Danemark.

Odoo 18 changed a bit how the `account.payment.order` is structured, payments of a different product are separated in different `account.payment`, making it so that the generated file had separate categories for sponsorships and gifts.

To fix this we first group payments that belong to the same `recurring.contract group`, and we iterate on that to generate the debit order (this way sponsorships and gifts belong to the same group).