### PR TITLE
REFACTOR Make queue_job dependencies optional

### DIFF
--- a/child_nordic/data/neutralize.sql
+++ b/child_nordic/data/neutralize.sql
@@ -40,7 +40,15 @@ update ir_cron set active = false;
 update base_automation SET active=false;
 
 -- Delete queue jobs
-delete from queue_job_replacement where state != 'done';
+DO $$
+BEGIN
+    IF EXISTS (SELECT FROM pg_tables WHERE tablename = 'queue_job') THEN
+        DELETE FROM queue_job WHERE state != 'done';
+    END IF;
+    IF EXISTS (SELECT FROM pg_tables WHERE tablename = 'queue_job_replacement') THEN
+        DELETE FROM queue_job_replacement WHERE state != 'done';
+    END IF;
+END $$;
 
 -- Delete mailchimp account
 DELETE FROM mailchimp_template;

--- a/child_nordic/data/neutralize.sql
+++ b/child_nordic/data/neutralize.sql
@@ -43,7 +43,7 @@ update ir_cron set active = false;
 update base_automation SET active=false;
 
 -- Delete queue jobs
-delete from queue_job where state != 'done';
+delete from queue_job_replacement where state != 'done';
 
 -- Delete mailchimp account
 DELETE FROM mailchimp_template;

--- a/child_nordic/data/neutralize.sql
+++ b/child_nordic/data/neutralize.sql
@@ -2,11 +2,8 @@
 -- ruff: noqa: E501
 
 -- Children on hold
-delete from correspondence where child_id IN (select id from compassion_child where state in ('N','I'));
-delete from sponsorship_gift where child_id IN (select id from compassion_child where state in ('N','I'));
-delete from recurring_contract where child_id IN (select id from compassion_child where state in ('N','I'));
-delete from compassion_child where state in ('N','I');
-delete from compassion_hold where state = 'active';
+UPDATE compassion_child SET state = 'R' where state in ('N','I');
+UPDATE compassion_hold SET state = 'expired' where state = 'active';
 
 -- Changing parameters
 update ir_config_parameter set value = 'https://stage.compassion.se' where key = 'web.external.url';

--- a/compassion_nordic_accounting/models/account_general_ledger.py
+++ b/compassion_nordic_accounting/models/account_general_ledger.py
@@ -1,4 +1,5 @@
 from odoo import api, models
+from odoo.tools import SQL
 
 from odoo.addons.l10n_se_sie4_export.models.account_general_ledger import (
     DATEFORMAT_SIE4,
@@ -31,42 +32,61 @@ class AccountGeneralLedger(models.AbstractModel):
 
     @api.model
     def _export_l10n_se_sie4_verification(self, options):
-        """
-        Unfortunately, the parent method cannot be patched to filter out
-        off-balance accounts, so we override it completely.
-        """
+        # Complete code copied from enterprise waiting for our fix to be merged
+        # see https://github.com/odoo/enterprise/pull/122499#event-27434439701
         sie4_verification_lines = []
-        dates = self._get_l10n_se_sie4_dates(options)
-        company_id = options["companies"][0]["id"]
-        unsupported_display_type = {"line_note", "line_section"}
-        moves = self.env["account.move"].search(
-            [
-                *self.env["account.move"]._check_company_domain(company_id),
-                ("state", "=", "posted"),
-                ("date", ">=", dates["curr_date_from"]),
-                ("date", "<=", dates["curr_date_to"]),
-            ]
+        report = self.env["account.report"].browse(options.get("report_id"))
+        company_ids = report.get_report_company_ids(options)
+        query = report._get_report_query(options, "strict_range", [])
+        account_alias = query.left_join(
+            lhs_alias="account_move_line",
+            lhs_column="account_id",
+            rhs_table="account_account",
+            rhs_column="id",
+            link="account_id",
         )
-
-        for verification_idx, move in enumerate(moves.sorted(reverse=True), start=1):
-            transactions = []
-            for line in move.line_ids:
-                if (
-                    line.display_type not in unsupported_display_type
-                    and not line.account_id.is_off_balance
-                ):
-                    transactions.append(
-                        f"    #TRANS {line.account_id.code} {{}} {line.balance}"
+        account_env = self.env["account.account"].with_context(
+            allowed_company_ids=company_ids
+        )
+        account_code = account_env._field_to_sql(account_alias, "code", query)
+        sql_query = SQL(
+            """
+            SELECT m.id                      AS move_id,
+                   m.name                    AS move_name,
+                   m.date                    AS move_date,
+                   %(account_code)s          AS account_code,
+                   account_move_line.balance AS balance
+            FROM %(table)s
+                     JOIN account_move m ON m.id = account_move_line.move_id
+            WHERE %(where_clause)s
+            ORDER BY m.date ASC, m.name ASC, m.id ASC, account_move_line.id ASC
+            """,
+            account_code=account_code,
+            table=query.from_clause,
+            where_clause=query.where_clause,
+        )
+        self.env.flush_all()
+        self.env.cr.execute(sql_query)
+        last_move_id = None
+        verification_idx = 0
+        for row in self.env.cr.dictfetchall():
+            current_move_id = row["move_id"]
+            if current_move_id != last_move_id:
+                if last_move_id is not None:
+                    sie4_verification_lines.append("}")
+                verification_idx += 1
+                move_date_str = row["move_date"].strftime(DATEFORMAT_SIE4)
+                sie4_verification_lines.extend(
+                    (
+                        f'#VER A {verification_idx} {move_date_str} '
+                        f'"{row["move_name"]}"',
+                        "{",
                     )
-
-            sie4_verification_lines.extend(
-                (
-                    f"#VER A {verification_idx} {move.date.strftime(DATEFORMAT_SIE4)} "
-                    f'"{move.name}"',
-                    "{",
-                    *transactions,
-                    "}",
                 )
+                last_move_id = current_move_id
+            sie4_verification_lines.append(
+                f'    #TRANS {row["account_code"]} {{}} {row["balance"]}'
             )
-
+        if last_move_id is not None:
+            sie4_verification_lines.append("}")
         return sie4_verification_lines

--- a/partner_communication_nordic/models/contracts.py
+++ b/partner_communication_nordic/models/contracts.py
@@ -36,10 +36,11 @@ class RecurringContract(models.Model):
         res = super().contract_waiting()
         new_sponsorships = self.filtered(lambda c: "S" in c.type and not c.is_active)
         if new_sponsorships:
-            new_sponsorships.with_delay(
+            new_sponsorships.with_delay_sh(
+                "_new_dossier",
                 channel="root.partner_communication",
                 identity_key=f"{self._name}.send_new_dossier.{new_sponsorships.ids}",
-            )._new_dossier()
+            )
         return res
 
     def _new_dossier(self):
@@ -122,15 +123,15 @@ class RecurringContract(models.Model):
             )
             send_to_correspondent = correspondent != payer and correspondent.email
             if send_to_correspondent or send_to_payer:
-                sponsorship.with_delay(
+                sponsorship.with_delay_sh(
+                    "send_communication",
+                    self.env.ref(
+                        "partner_communication_nordic.config_birthday_reminder"
+                    ).id,
+                    send_to_correspondent,
+                    send_to_payer and send_to_correspondent,
                     channel="root.partner_communication",
                     identity_key=f"{sponsorship._name}."
                     f"send_birthday_reminder.{sponsorship.id}",
                     priority=50,
-                ).send_communication(
-                    self.env.ref(
-                        "partner_communication_nordic.config_birthday_reminder"
-                    ),
-                    correspondent=send_to_correspondent,
-                    both=send_to_payer and send_to_correspondent,
                 )

--- a/wordpress_api/fastapi/giving_platform_service.py
+++ b/wordpress_api/fastapi/giving_platform_service.py
@@ -38,10 +38,8 @@ class GivingPlatformService(AbstractModel):
         """
         # Make sure we don't lose the information received.
         json_data = donate_data.model_dump_json()
-        self.env["ir.logging"].with_delay(
-            channel="root.wordpress_api",
-            description="Log donation from Giving Platform",
-        ).create(
+        self.env["ir.logging"].with_delay_sh(
+            "create",
             {
                 "level": "info",
                 "name": "giving_platform_service.donate",
@@ -51,7 +49,9 @@ class GivingPlatformService(AbstractModel):
                 "path": __file__,
                 "func": "donate",
                 "line": inspect.currentframe().f_lineno,
-            }
+            },
+            channel="root.wordpress_api",
+            description="Log donation from Giving Platform",
         )
         if not donate_data.donor_phone and not donate_data.donor_email:
             raise HTTPException(
@@ -134,5 +134,7 @@ class GivingPlatformService(AbstractModel):
                     }
                 )
             )
-        donation.with_delay(channel="root.wordpress_api").process_donation(json_data)
+        donation.with_delay_sh(
+            "process_donation", json_data, channel="root.wordpress_api"
+        )
         return DonateResponseModel(success=True, odoo_id=donation.id)


### PR DESCRIPTION
- NEW module queue_job_sh_safe that will safely use queue_jobs when available and fallback to an alternate mechanism with ir_cron in case the module is not installed.
- This is useful for Nordic using odoo.sh on which queue jobs are prohibited and not optimal for the infrastructure